### PR TITLE
[YLD-99] Responsive pool detail

### DIFF
--- a/app/app/components/TopCard.tsx
+++ b/app/app/components/TopCard.tsx
@@ -31,8 +31,8 @@ export const TopCard: React.FC<TopCardProps> = ({
   const isMobile = useMobileDetection();
 
   return (
-    <TranslucentCard className="md:p-4 p-1 rounded-2xl flex flex-col items-start">
-      <div className="flex items-center md:mb-7 p-1 md:p-0 mb-2">
+    <TranslucentCard className="md:p-4 p-2 rounded-2xl flex flex-col items-start">
+      <div className="flex items-center md:mb-7 md:p-0 mb-2">
         <Image
           src={getLogoPath(asset)}
           alt={`${getAssetSymbol(asset)} logo`}

--- a/app/app/explore/components/LiquidityPoolCardMobile.tsx
+++ b/app/app/explore/components/LiquidityPoolCardMobile.tsx
@@ -1,0 +1,59 @@
+import TranslucentCard from "@/app/TranslucentCard";
+import { addDollarSignAndSuffix, calculateVolumeDepthRatio, calculateVolumeUSD, formatNumber, getAssetSymbol, getFormattedPoolTVL, getLogoPath } from "@/app/utils";
+import { PoolDetail } from "@/midgard";
+import Image from "next/image";
+import Link from "next/link";
+
+export default function LiquidityPoolCardMobile({ pool, runePriceUSD }: { pool: PoolDetail, runePriceUSD: number }) {
+  return (
+    <Link key={pool.asset} href={`/explore/pools/${pool.asset}`}>
+      <TranslucentCard className="rounded-xl mb-1.5">
+        <div className="flex items-center w-full flex-col p-1">
+          <div className="w-full flex items-center mb-2">
+            <Image
+              src={getLogoPath(pool.asset)}
+              alt={`${getAssetSymbol(pool.asset)} logo`}
+              width={26}
+              height={26}
+              className="rounded-full"
+            />
+            <span className="ml-3 font-medium text-sm md:text-base">
+              {getAssetSymbol(pool.asset)}
+            </span>
+          </div>
+          <div className="flex flex-row w-full gap-1">
+            <div className="flex-1 p-2 rounded-xl bg-white">
+              <p className="text-sm text-neutral mb-1">
+                {addDollarSignAndSuffix(calculateVolumeUSD(pool, runePriceUSD))}
+              </p>
+              <p className="text-xs text-neutral-800">Volume (24h)</p>
+            </div>
+            <div className="flex-1 p-2 rounded-xl bg-white">
+              <p className="text-sm text-neutral mb-1">
+                {formatNumber(
+                  calculateVolumeDepthRatio(pool, runePriceUSD) * 100,
+                  2,
+                  2,
+                )}
+                %
+              </p>
+              <p className="text-xs text-neutral-800">Volume/Depth</p>
+            </div>
+            <div className="flex-1 p-2 rounded-xl bg-white">
+              <p className="text-sm text-neutral mb-1">
+                {getFormattedPoolTVL(pool, runePriceUSD)}
+              </p>
+              <p className="text-xs text-neutral-800">TVL</p>
+            </div>
+            <div className="flex-1 p-2 rounded-xl bg-white">
+              <p className="text-sm text-neutral mb-1">
+                {formatNumber(parseFloat(pool.poolAPY) * 100, 2, 2)}%
+              </p>
+              <p className="text-xs text-neutral-800">APR</p>
+            </div>
+          </div>
+        </div>
+      </TranslucentCard>
+    </Link>
+  )
+};

--- a/app/app/explore/pools/LiquidityPools.tsx
+++ b/app/app/explore/pools/LiquidityPools.tsx
@@ -1,6 +1,6 @@
 import { useState, useMemo } from "react";
 import Image from "next/image";
-import { PoolDetail, PoolDetails } from "@/midgard";
+import { PoolDetails } from "@/midgard";
 import { FixedSizeList as List } from "react-window";
 import AutoSizer from "react-virtualized-auto-sizer";
 import {
@@ -24,6 +24,7 @@ import TopCards from "@/app/components/TopCards";
 import { SortDirection } from "@shared/components/ui/types";
 import { SortableHeader } from "@shared/components/ui";
 import Link from "next/link";
+import LiquidityPoolCardMobile from "../components/LiquidityPoolCardMobile";
 
 interface LiquidityPoolsProps {
   pools: PoolDetails;
@@ -118,56 +119,6 @@ const LiquidityPools: React.FC<LiquidityPoolsProps> = ({
     apr: parseFloat(pool.poolAPY),
   }));
 
-  const MobileCard = ({ pool }: { pool: PoolDetail }) => (
-    <TranslucentCard className="rounded-xl mb-1.5">
-      <div className="flex items-center w-full flex-col p-1">
-        <div className="w-full flex items-center mb-2">
-          <Image
-            src={getLogoPath(pool.asset)}
-            alt={`${getAssetSymbol(pool.asset)} logo`}
-            width={26}
-            height={26}
-            className="rounded-full"
-          />
-          <span className="ml-3 font-medium text-sm md:text-base">
-            {getAssetSymbol(pool.asset)}
-          </span>
-        </div>
-        <div className="flex flex-row w-full gap-1">
-          <div className="flex-1 p-2 rounded-xl bg-white">
-            <p className="text-sm text-neutral mb-1">
-              {addDollarSignAndSuffix(calculateVolumeUSD(pool, runePriceUSD))}
-            </p>
-            <p className="text-xs text-neutral-800">Volume (24h)</p>
-          </div>
-          <div className="flex-1 p-2 rounded-xl bg-white">
-            <p className="text-sm text-neutral mb-1">
-              {formatNumber(
-                calculateVolumeDepthRatio(pool, runePriceUSD) * 100,
-                2,
-                2,
-              )}
-              %
-            </p>
-            <p className="text-xs text-neutral-800">Volume/Depth</p>
-          </div>
-          <div className="flex-1 p-2 rounded-xl bg-white">
-            <p className="text-sm text-neutral mb-1">
-              {getFormattedPoolTVL(pool, runePriceUSD)}
-            </p>
-            <p className="text-xs text-neutral-800">TVL</p>
-          </div>
-          <div className="flex-1 p-2 rounded-xl bg-white">
-            <p className="text-sm text-neutral mb-1">
-              {formatNumber(parseFloat(pool.poolAPY) * 100, 2, 2)}%
-            </p>
-            <p className="text-xs text-neutral-800">APR</p>
-          </div>
-        </div>
-      </div>
-    </TranslucentCard>
-  );
-
   const MobileRow = ({
     index,
     style,
@@ -178,7 +129,7 @@ const LiquidityPools: React.FC<LiquidityPoolsProps> = ({
     const pool = sortedPools[index];
     return (
       <div style={style}>
-        <MobileCard pool={pool} />
+        <LiquidityPoolCardMobile pool={pool} runePriceUSD={runePriceUSD} />
       </div>
     );
   };
@@ -188,7 +139,7 @@ const LiquidityPools: React.FC<LiquidityPoolsProps> = ({
       <div className="w-full">
         {/* Hidden measurement div */}
         <div ref={measureRef}>
-          <MobileCard pool={sortedPools[0]} />
+          <LiquidityPoolCardMobile pool={sortedPools[0]} runePriceUSD={runePriceUSD} />
         </div>
 
         {/* Sort header */}

--- a/app/app/explore/pools/[asset]/PoolDetail.tsx
+++ b/app/app/explore/pools/[asset]/PoolDetail.tsx
@@ -225,7 +225,7 @@ export default function PoolDetail({ pool, runePriceUSD }: PoolDetailProps) {
 
   const renderPositionContent = () => (
     <>
-      <div className="mb-8 bg-white rounded-xl w-full p-3">
+      <div className="mb-2 md:mb-8 bg-white rounded-xl w-full p-3">
         <div className="text-gray-700 font-medium text-lg mb-2">DEPOSIT</div>
         <div className="flex justify-between">
           <div className="text-2xl font-medium text-gray-900">
@@ -237,7 +237,7 @@ export default function PoolDetail({ pool, runePriceUSD }: PoolDetailProps) {
         </div>
       </div>
 
-      <div className="mb-8 bg-white rounded-xl w-full p-3">
+      <div className="md:mb-8 bg-white rounded-xl w-full p-3">
         <div className="text-gray-700 font-medium text-lg mb-2">GAIN</div>
         <div className="flex justify-between">
           <div className="text-2xl font-medium text-gray-900">
@@ -268,15 +268,15 @@ export default function PoolDetail({ pool, runePriceUSD }: PoolDetailProps) {
     <div className="md:mx-16">
       <Link
         href="/explore/pools"
-        className="inline-flex items-center mb-8 text-foreground text-2xl font-bold font-gt-america-ext hover:opacity-50 transition-opacity"
+        className="inline-flex items-center md:mb-8 text-foreground md:text-2xl font-bold font-gt-america-ext hover:opacity-50 transition-opacity"
       >
         <BackArrow className="mr-2" />
         ALL POOLS
       </Link>
 
-      <div className="grid grid-cols-12 gap-20">
-        <div className="col-span-6">
-          <h2 className="text-2xl font-medium mb-6 text-foreground font-gt-america-ext">
+      <div className="grid grid-cols-12 md:gap-20">
+        <div className="col-span-12 md:col-span-6">
+          <h2 className="my-2 md:mt-0 md:text-2xl font-medium md:mb-6 text-foreground font-gt-america-ext">
             OVERVIEW
           </h2>
 
@@ -285,7 +285,7 @@ export default function PoolDetail({ pool, runePriceUSD }: PoolDetailProps) {
             formattedTVL={formattedTVL}
             apr={parseFloat(pool.poolAPY)}
           >
-            <div className="space-y-4 w-full mt-8">
+            <div className="space-y-4 w-full mt-8 px-3 md:px-3">
               <div className="flex justify-between items-center">
                 <span className="text-gray-500">Volume/Depth</span>
                 <span className="font-medium">
@@ -301,12 +301,12 @@ export default function PoolDetail({ pool, runePriceUSD }: PoolDetailProps) {
           </TopCard>
         </div>
 
-        <div className="col-span-6">
-          <h2 className="text-2xl font-medium mb-6 text-foreground font-gt-america-ext">
+        <div className="col-span-12 md:col-span-6">
+          <h2 className="my-2 md:mt-0 md:text-2xl font-medium md:mb-6 text-foreground font-gt-america-ext">
             YOUR POSITION
           </h2>
 
-          <TranslucentCard className="p-6 rounded-2xl flex flex-col shadow-md relative">
+          <TranslucentCard className="p-2 md:p-6 rounded-2xl flex flex-col shadow-md relative">
             {showLoadingState && (
               <div className="absolute inset-0 bg-white/50 flex items-center justify-center rounded-2xl">
                 <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary"></div>


### PR DESCRIPTION
Partially fix the issue https://linear.app/project-chaos/issue/YLD-99/pool-details-modal-mobile-view

The part of adapting the add liquidity modal is still pending, but as it moves to different path in a currently open PR I will wait until this is integrated to take out the [PR](https://github.com/yieldi-labs/yieldi-web/pull/40) with the changes and avoid unnecessary conflicts. 

Screenshot before the change

![image](https://github.com/user-attachments/assets/95662767-5966-4645-9044-aeb98299e317)

Screenshot after the change

![image](https://github.com/user-attachments/assets/812176e6-bb20-4e47-90af-be6128472a73)
