### PR TITLE
[YLD-114] Fix confirm modal for remove liquidity

### DIFF
--- a/app/app/dashboard/DashboardView.tsx
+++ b/app/app/dashboard/DashboardView.tsx
@@ -7,14 +7,18 @@ import PositionsList from "./components/PositionsList";
 import { PoolDetail } from "@/midgard";
 import PositionsPlaceholder from "./components/PositionsPlaceholder";
 import AddLiquidityModal from "../explore/components/AddLiquidityModal";
-import { PositionStats } from "@/hooks/dataTransformers/positionsTransformer";
+import { PositionStats, PositionType } from "@/hooks/dataTransformers/positionsTransformer";
 import { useLiquidityPositions } from "@/utils/PositionsContext";
 import Loader from "../components/Loader";
 import { useAppState } from "@/utils/context";
 import { emptyPositionStats } from "@/hooks/usePositionStats";
+import RemoveLiquidityModal from "../explore/components/RemoveLiquidityModal";
 
 export default function DashboardView() {
-  const [selectedPool, setSelectedPool] = useState<PoolDetail>();
+  const [selectedPool, setSelectedPool] = useState<PoolDetail | null>(null);
+  const [selectedPosition, setSelectedPosition] = useState<PositionStats | null>(null);
+  const [showRemoveLiquidityModal, setShowRemoveLiquidityModal] = useState(false);
+  const [showAddLiquidityModal, setShowAddLiquidityModal] = useState(false);
 
   const { positions, pools, isPending } = useLiquidityPositions();
   const { walletsState } = useAppState();
@@ -79,24 +83,41 @@ export default function DashboardView() {
           ) : (
             <PositionsList
               positions={allPositionsArray}
-              onAdd={(assetId) => {
-                setSelectedPool(pools?.find((pool) => pool.asset === assetId));
+              onAdd={(poolId) => {
+                setSelectedPool(pools?.find((pool) => pool.asset === poolId) || null);
+                setShowAddLiquidityModal(true)
               }}
-              onRemove={() => {}}
+              onRemove={(poolId: string, type: PositionType) => {
+                setSelectedPool(pools?.find((pool) => pool.asset === poolId) || null);
+                setSelectedPosition(positions[poolId][type])
+                setShowRemoveLiquidityModal(true)
+              }}
             />
           )
         ) : (
           <PositionsPlaceholder />
         )}
       </div>
-      {selectedPool && (
+      {showAddLiquidityModal && selectedPool && (
         <AddLiquidityModal
           pool={selectedPool}
           runePriceUSD={0}
           onClose={() => {
-            setSelectedPool(undefined);
+            setSelectedPool(null);
+            setShowAddLiquidityModal(false)
           }}
         />
+      )}
+      {showRemoveLiquidityModal && selectedPool && selectedPosition && (
+          <RemoveLiquidityModal
+            pool={selectedPool}
+            position={selectedPosition?.memberDetails}
+            onClose={() => {
+              setSelectedPool(null);
+              setSelectedPosition(null)
+              setShowRemoveLiquidityModal(false)
+            }}
+          />
       )}
     </main>
   );

--- a/app/app/dashboard/DashboardView.tsx
+++ b/app/app/dashboard/DashboardView.tsx
@@ -7,7 +7,10 @@ import PositionsList from "./components/PositionsList";
 import { PoolDetail } from "@/midgard";
 import PositionsPlaceholder from "./components/PositionsPlaceholder";
 import AddLiquidityModal from "../explore/components/AddLiquidityModal";
-import { PositionStats, PositionType } from "@/hooks/dataTransformers/positionsTransformer";
+import {
+  PositionStats,
+  PositionType,
+} from "@/hooks/dataTransformers/positionsTransformer";
 import { useLiquidityPositions } from "@/utils/PositionsContext";
 import Loader from "../components/Loader";
 import { useAppState } from "@/utils/context";
@@ -16,8 +19,10 @@ import RemoveLiquidityModal from "../explore/components/RemoveLiquidityModal";
 
 export default function DashboardView() {
   const [selectedPool, setSelectedPool] = useState<PoolDetail | null>(null);
-  const [selectedPosition, setSelectedPosition] = useState<PositionStats | null>(null);
-  const [showRemoveLiquidityModal, setShowRemoveLiquidityModal] = useState(false);
+  const [selectedPosition, setSelectedPosition] =
+    useState<PositionStats | null>(null);
+  const [showRemoveLiquidityModal, setShowRemoveLiquidityModal] =
+    useState(false);
   const [showAddLiquidityModal, setShowAddLiquidityModal] = useState(false);
 
   const { positions, pools, isPending } = useLiquidityPositions();
@@ -84,13 +89,17 @@ export default function DashboardView() {
             <PositionsList
               positions={allPositionsArray}
               onAdd={(poolId) => {
-                setSelectedPool(pools?.find((pool) => pool.asset === poolId) || null);
-                setShowAddLiquidityModal(true)
+                setSelectedPool(
+                  pools?.find((pool) => pool.asset === poolId) || null,
+                );
+                setShowAddLiquidityModal(true);
               }}
               onRemove={(poolId: string, type: PositionType) => {
-                setSelectedPool(pools?.find((pool) => pool.asset === poolId) || null);
-                setSelectedPosition(positions[poolId][type])
-                setShowRemoveLiquidityModal(true)
+                setSelectedPool(
+                  pools?.find((pool) => pool.asset === poolId) || null,
+                );
+                setSelectedPosition(positions[poolId][type]);
+                setShowRemoveLiquidityModal(true);
               }}
             />
           )
@@ -104,20 +113,20 @@ export default function DashboardView() {
           runePriceUSD={0}
           onClose={() => {
             setSelectedPool(null);
-            setShowAddLiquidityModal(false)
+            setShowAddLiquidityModal(false);
           }}
         />
       )}
       {showRemoveLiquidityModal && selectedPool && selectedPosition && (
-          <RemoveLiquidityModal
-            pool={selectedPool}
-            position={selectedPosition?.memberDetails}
-            onClose={() => {
-              setSelectedPool(null);
-              setSelectedPosition(null)
-              setShowRemoveLiquidityModal(false)
-            }}
-          />
+        <RemoveLiquidityModal
+          pool={selectedPool}
+          position={selectedPosition?.memberDetails}
+          onClose={() => {
+            setSelectedPool(null);
+            setSelectedPosition(null);
+            setShowRemoveLiquidityModal(false);
+          }}
+        />
       )}
     </main>
   );

--- a/app/app/dashboard/components/PositionRow.tsx
+++ b/app/app/dashboard/components/PositionRow.tsx
@@ -12,7 +12,7 @@ import Loader from "@/app/components/Loader";
 interface PositionsRow {
   position: PositionStats;
   onAdd: (assetId: string) => void;
-  onRemove: (assetId: string) => void;
+  onRemove: (poolId: string, type: PositionType) => void;
   hideAddButton?: boolean;
 }
 
@@ -62,7 +62,7 @@ export default function PositionRow({
               className="border-red border-2 text-red font-bold px-6 py-1 rounded-full
                         hover:text-opacity-50 hover:border-opacity-50 transition-all 
                         disabled:opacity-50 disabled:cursor-not-allowed ml-2"
-              onClick={() => onRemove(position.assetId)}
+              onClick={() => onRemove(position.assetId, position.type)}
               disabled={position.type !== PositionType.SLP}
             >
               Remove

--- a/app/app/dashboard/components/PositionsList.tsx
+++ b/app/app/dashboard/components/PositionsList.tsx
@@ -2,12 +2,12 @@ import React, { useMemo, useState } from "react";
 import { SortableHeader } from "@shared/components/ui";
 import { SortDirection } from "@shared/components/ui/types";
 import PositionRow from "./PositionRow";
-import { PositionStats } from "@/hooks/dataTransformers/positionsTransformer";
+import { PositionStats, PositionType } from "@/hooks/dataTransformers/positionsTransformer";
 
 interface PositionsList {
   positions: PositionStats[];
   onAdd: (assetId: string) => void;
-  onRemove: (assetId: string) => void;
+  onRemove: (poolId: string, type: PositionType) => void;
 }
 
 enum PoolSortKey {

--- a/app/app/dashboard/components/PositionsList.tsx
+++ b/app/app/dashboard/components/PositionsList.tsx
@@ -2,7 +2,10 @@ import React, { useMemo, useState } from "react";
 import { SortableHeader } from "@shared/components/ui";
 import { SortDirection } from "@shared/components/ui/types";
 import PositionRow from "./PositionRow";
-import { PositionStats, PositionType } from "@/hooks/dataTransformers/positionsTransformer";
+import {
+  PositionStats,
+  PositionType,
+} from "@/hooks/dataTransformers/positionsTransformer";
 
 interface PositionsList {
   positions: PositionStats[];

--- a/app/app/explore/components/RemoveLiquidityModal.tsx
+++ b/app/app/explore/components/RemoveLiquidityModal.tsx
@@ -102,10 +102,7 @@ export default function RemoveLiquidityModal({
 
       if (hash) {
         markPositionAsPending(pool.asset, PositionType.SLP); // TODO: Update with support for SLP and DLP
-        setTimeout(() => {
-          setTxHash(hash);
-          onClose(true);
-        }, 0);
+        setTxHash(hash);
       }
     } catch (err) {
       console.error("Failed to remove liquidity:", err);

--- a/app/app/utils.tsx
+++ b/app/app/utils.tsx
@@ -268,7 +268,6 @@ export async function bitcoinConnectInjected() {
       if (response.status === "error") {
         throw new Error(response.error.message);
       }
-      console.log(response);
       return response.result.txid;
     },
   };

--- a/app/hooks/usePositionStats.ts
+++ b/app/hooks/usePositionStats.ts
@@ -72,7 +72,6 @@ export function usePositionStats({
     enabled: addresses.length > 0,
     refetchInterval, // TODO: Dependant on pending positions (transaction pending and block confirmation times of pending chains)
     queryFn: async () => {
-      console.log("New fech with addresses", addresses);
       const resultPools = await getPools();
       const pools = resultPools.data;
       const result = await getMemberDetail({


### PR DESCRIPTION
## Bugs

- The transaction confirmation modal does not exit after a remove liquidity action.
- The 'Remove' button in the Dashboard view does not open the cash withdrawal mode.

## Fixes

- Now the confirmation modal is displayed after executing the remove liquidity process.
- Now the remove modal appears when clicking on the remove button from the dashboard view.