### PR TITLE
[YLD-153][Add liquidity is broken due to localstorage refactor]

### DIFF
--- a/app/app/explore/components/AddLiquidityModal.tsx
+++ b/app/app/explore/components/AddLiquidityModal.tsx
@@ -21,7 +21,6 @@ import {
   PositionType,
 } from "@/hooks/dataTransformers/positionsTransformer";
 import { ChainKey } from "@/utils/wallet/constants";
-import { baseAmount } from "@xchainjs/xchain-util";
 
 interface AddLiquidityModalProps {
   pool: IPoolDetail;
@@ -47,14 +46,8 @@ export default function AddLiquidityModal({
   const { toggleWalletModal, walletsState, balanceList, isWalletConnected } =
     useAppState();
 
-  const [assetChain] = useMemo(
-    () => parseAssetString(pool.asset),
-    [pool.asset],
-  );
-  const chainKey = useMemo(
-    () => getChainKeyFromChain(assetChain),
-    [assetChain],
-  );
+  const [assetChain] = parseAssetString(pool.asset);
+  const chainKey = getChainKeyFromChain(assetChain);
   const selectedWallet = walletsState[chainKey] || null;
   const [assetAmount, setAssetAmount] = useState("");
   const [runeAmount, setRuneAmount] = useState("");
@@ -68,13 +61,6 @@ export default function AddLiquidityModal({
 
   const poolNativeDecimal = parseInt(pool.nativeDecimal);
   const assetMinimalUnit = 1 / 10 ** poolNativeDecimal;
-  const baseAssetMinimalUnit = baseAmount(1, poolNativeDecimal)
-    .amount()
-    .toNumber();
-  console.log({
-    assetMinimalUnit,
-    baseAssetMinimalUnit,
-  });
   const runeMinimalUnit = 1 / 10 ** DECIMALS;
   const runeBalance = useMemo(() => {
     if (!balanceList) return 0;
@@ -198,7 +184,7 @@ export default function AddLiquidityModal({
       if (isDualSided && parsedRuneAmount) {
         pairedAddress = getAssetWallet(pool.asset).address;
         const result = await addLiquidity({
-          asset: pool.asset,
+          asset: "THOR.RUNE",
           amount: 0,
           pairedAddress,
           runeAmount: parsedRuneAmount,

--- a/app/app/explore/components/AddLiquidityModal.tsx
+++ b/app/app/explore/components/AddLiquidityModal.tsx
@@ -189,6 +189,7 @@ export default function AddLiquidityModal({
         });
         if (result) {
           setAssetTxHash(result);
+          setShowConfirmation(true);
         } else {
           throw new Error("Failed to add asset liquidity.");
         }
@@ -197,13 +198,14 @@ export default function AddLiquidityModal({
       if (isDualSided && parsedRuneAmount) {
         pairedAddress = getAssetWallet(pool.asset).address;
         const result = await addLiquidity({
-          asset: "THOR.RUNE",
+          asset: pool.asset,
           amount: 0,
           pairedAddress,
           runeAmount: parsedRuneAmount,
         });
         if (result) {
           setRuneTxHash(result);
+          setShowConfirmation(true);
         } else {
           throw new Error("Failed to add Rune liquidity.");
         }
@@ -214,10 +216,6 @@ export default function AddLiquidityModal({
         type,
         PositionStatus.LP_POSITION_DEPOSIT_PENDING,
       );
-
-      if (assetTxHash || runeTxHash) {
-        setShowConfirmation(true);
-      }
     } catch (err) {
       console.error("Failed to add liquidity:", err);
     } finally {
@@ -266,7 +264,7 @@ export default function AddLiquidityModal({
   const type = isDualSided ? PositionType.DLP : PositionType.SLP;
   if (
     showConfirmation &&
-    assetTxHash &&
+    (assetTxHash || runeTxHash) && // Changed condition
     positions &&
     positions[pool.asset][type]
   ) {

--- a/app/app/explore/components/AddLiquidityModal.tsx
+++ b/app/app/explore/components/AddLiquidityModal.tsx
@@ -37,7 +37,11 @@ export default function AddLiquidityModal({
   onClose,
 }: AddLiquidityModalProps) {
   const inputRef = useRef<HTMLInputElement>(null);
-  const { error: liquidityError, addLiquidity, getAssetWallet } = useLiquidityPosition({
+  const {
+    error: liquidityError,
+    addLiquidity,
+    getAssetWallet,
+  } = useLiquidityPosition({
     pool,
   });
   const { toggleWalletModal, walletsState, balanceList, isWalletConnected } =
@@ -64,11 +68,13 @@ export default function AddLiquidityModal({
 
   const poolNativeDecimal = parseInt(pool.nativeDecimal);
   const assetMinimalUnit = 1 / 10 ** poolNativeDecimal;
-  const baseAssetMinimalUnit = baseAmount(1, poolNativeDecimal).amount().toNumber();
+  const baseAssetMinimalUnit = baseAmount(1, poolNativeDecimal)
+    .amount()
+    .toNumber();
   console.log({
     assetMinimalUnit,
     baseAssetMinimalUnit,
-  })
+  });
   const runeMinimalUnit = 1 / 10 ** DECIMALS;
   const runeBalance = useMemo(() => {
     if (!balanceList) return 0;
@@ -187,7 +193,7 @@ export default function AddLiquidityModal({
           throw new Error("Failed to add asset liquidity.");
         }
       }
-      
+
       if (isDualSided && parsedRuneAmount) {
         pairedAddress = getAssetWallet(pool.asset).address;
         const result = await addLiquidity({
@@ -258,7 +264,12 @@ export default function AddLiquidityModal({
   };
 
   const type = isDualSided ? PositionType.DLP : PositionType.SLP;
-  if (showConfirmation && assetTxHash && positions && positions[pool.asset][type]) {
+  if (
+    showConfirmation &&
+    assetTxHash &&
+    positions &&
+    positions[pool.asset][type]
+  ) {
     const position = positions[pool.asset][type];
     return (
       <TransactionConfirmationModal

--- a/app/app/explore/components/RemoveLiquidityModal.tsx
+++ b/app/app/explore/components/RemoveLiquidityModal.tsx
@@ -130,7 +130,7 @@ export default function RemoveLiquidityModal({
     return (
       <TransactionConfirmationModal
         position={positions[pool.asset][PositionType.SLP]} // TODO: Update with support for SLP and DLP
-        txHash={txHash}
+        assetHash={txHash}
         onClose={() => {
           setTxHash(null);
           onClose(true);

--- a/app/app/explore/components/TransactionConfirmationModal.tsx
+++ b/app/app/explore/components/TransactionConfirmationModal.tsx
@@ -4,6 +4,7 @@ import {
   PositionStats,
   PositionStatus,
 } from "@/hooks/dataTransformers/positionsTransformer";
+import { useMemo } from "react";
 
 interface TransactionConfirmationModalProps {
   position: PositionStats | null;
@@ -26,6 +27,16 @@ export default function TransactionConfirmationModal({
   const runeHashRunescanUrl = runeHash
     ? `https://runescan.io/tx/${runeHash}`
     : undefined;
+
+  const getChainNameFromPosition = (position: PositionStats | null) => {
+    if (!position) return "";
+    const poolName = position.pool.asset;
+    return poolName.split(".")[0];
+  };
+  const chainName = useMemo(
+    () => getChainNameFromPosition(position),
+    [position],
+  );
 
   const ExternalLinkIcon = () => (
     <svg
@@ -77,25 +88,33 @@ export default function TransactionConfirmationModal({
 
         {/* Explorer Links */}
         <div className="w-full space-y-3">
-          <a
-            href={assetHashThorchainUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center justify-center w-full p-4 bg-white rounded-xl hover:bg-gray-50 transition-colors border text-foreground group"
-          >
-            <span className="mr-2">View on THORChain.net</span>
-            <ExternalLinkIcon />
-          </a>
+          {assetHash && (
+            <>
+              <a
+                href={assetHashThorchainUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center justify-center w-full p-4 bg-white rounded-xl hover:bg-gray-50 transition-colors border text-foreground group"
+              >
+                <span className="mr-2">
+                  View {chainName} transaction on THORChain.net
+                </span>
+                <ExternalLinkIcon />
+              </a>
 
-          <a
-            href={assetHashRunescanUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center justify-center w-full p-4 bg-white rounded-xl hover:bg-gray-50 transition-colors border text-foreground group"
-          >
-            <span className="mr-2">View on Runescan</span>
-            <ExternalLinkIcon />
-          </a>
+              <a
+                href={assetHashRunescanUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center justify-center w-full p-4 bg-white rounded-xl hover:bg-gray-50 transition-colors border text-foreground group"
+              >
+                <span className="mr-2">
+                  View {chainName} transaction on Runescan
+                </span>
+                <ExternalLinkIcon />
+              </a>
+            </>
+          )}
 
           {runeHash && (
             <>
@@ -105,7 +124,9 @@ export default function TransactionConfirmationModal({
                 rel="noopener noreferrer"
                 className="flex items-center justify-center w-full p-4 bg-white rounded-xl hover:bg-gray-50 transition-colors border text-foreground group"
               >
-                <span className="mr-2">View Rune on THORChain.net</span>
+                <span className="mr-2">
+                  View Rune transaction on THORChain.net
+                </span>
                 <ExternalLinkIcon />
               </a>
 
@@ -115,7 +136,7 @@ export default function TransactionConfirmationModal({
                 rel="noopener noreferrer"
                 className="flex items-center justify-center w-full p-4 bg-white rounded-xl hover:bg-gray-50 transition-colors border text-foreground group"
               >
-                <span className="mr-2">View Rune on Runescan</span>
+                <span className="mr-2">View Rune transaction on Runescan</span>
                 <ExternalLinkIcon />
               </a>
             </>
@@ -124,8 +145,8 @@ export default function TransactionConfirmationModal({
 
         {/* Hash Preview */}
         <div className="mt-4 text-sm text-gray-500 truncate max-w-full">
-          Asset Transaction Hash: {assetHash}
-          {runeHash && `Rune Transaction Hash: ${runeHash}`}
+          {assetHash && <p>{`${chainName} Transaction Hash: ${assetHash}`}</p>}
+          {runeHash && <p>{`Rune Transaction Hash: ${runeHash}</p>`}</p>}
         </div>
       </div>
     </Modal>

--- a/app/app/explore/components/TransactionConfirmationModal.tsx
+++ b/app/app/explore/components/TransactionConfirmationModal.tsx
@@ -16,8 +16,9 @@ export default function TransactionConfirmationModal({
   txHash,
   onClose,
 }: TransactionConfirmationModalProps) {
-  const thorchainUrl = `https://thorchain.net/tx/${txHash}`;
-  const runescanUrl = `https://runescan.io/tx/${txHash}`;
+  const txHashes = txHash.split(",");
+  const thorchainUrl = `https://thorchain.net/tx/${txHashes[0]}`;
+  const runescanUrl = txHashes[1] ? `https://runescan.io/tx/${txHashes[1]}` : null;
 
   const ExternalLinkIcon = () => (
     <svg
@@ -79,20 +80,22 @@ export default function TransactionConfirmationModal({
             <ExternalLinkIcon />
           </a>
 
-          <a
-            href={runescanUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center justify-center w-full p-4 bg-white rounded-xl hover:bg-gray-50 transition-colors border text-foreground group"
-          >
-            <span className="mr-2">View on Runescan</span>
-            <ExternalLinkIcon />
-          </a>
+          {runescanUrl && (
+            <a
+              href={runescanUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center justify-center w-full p-4 bg-white rounded-xl hover:bg-gray-50 transition-colors border text-foreground group"
+            >
+              <span className="mr-2">View on Runescan</span>
+              <ExternalLinkIcon />
+            </a>
+          )}
         </div>
 
         {/* Hash Preview */}
         <div className="mt-4 text-sm text-gray-500 truncate max-w-full">
-          Hash: {txHash}
+          Hash: {txHashes.join(", ")}
         </div>
       </div>
     </Modal>

--- a/app/app/explore/components/TransactionConfirmationModal.tsx
+++ b/app/app/explore/components/TransactionConfirmationModal.tsx
@@ -12,36 +12,67 @@ interface TransactionConfirmationModalProps {
   onClose: () => void;
 }
 
+interface ExplorerLinkProps {
+  url: string;
+  text: string;
+}
+
+const ExternalLinkIcon = () => (
+  <svg
+    className="w-4 h-4 transition-transform group-hover:translate-x-0.5"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M7 17L17 7" />
+    <path d="M7 7h10v10" />
+  </svg>
+);
+
+const ExplorerLink = ({ url, text }: ExplorerLinkProps) => {
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="flex items-center justify-center w-full p-4 bg-white rounded-xl hover:bg-gray-50 transition-colors border text-foreground group"
+    >
+      <span className="mr-2">{text}</span>
+      <ExternalLinkIcon />
+    </a>
+  );
+};
+
 export default function TransactionConfirmationModal({
   position,
   assetHash,
   runeHash,
   onClose,
 }: TransactionConfirmationModalProps) {
-  const assetHashThorchainUrl = `https://thorchain.net/tx/${assetHash}`;
-  const runeHashThorchainUrl = runeHash
-    ? `https://thorchain.net/tx/${runeHash}`
-    : undefined;
-  const assetHashRunescanUrl = `https://runescan.io/tx/${assetHash}`;
-  const runeHashRunescanUrl = runeHash
-    ? `https://runescan.io/tx/${runeHash}`
-    : undefined;
   const chainName = position ? position.pool.asset.split(".")[0] : "";
 
-  const ExternalLinkIcon = () => (
-    <svg
-      className="w-4 h-4 transition-transform group-hover:translate-x-0.5"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    >
-      <path d="M7 17L17 7" />
-      <path d="M7 7h10v10" />
-    </svg>
-  );
+  const createExplorerLinks = (hash: string | null, chainName: string) => {
+    return hash
+      ? [
+          {
+            url: `https://thorchain.net/tx/${hash}`,
+            text: `View ${chainName} transaction on THORChain.net`,
+          },
+          {
+            url: `https://runescan.io/tx/${hash}`,
+            text: `View ${chainName} transaction on Runescan`,
+          },
+        ]
+      : [];
+  };
+
+  const links = {
+    asset: createExplorerLinks(assetHash, chainName),
+    rune: runeHash ? createExplorerLinks(runeHash, "Rune") : [],
+  };
 
   return (
     <Modal
@@ -50,7 +81,6 @@ export default function TransactionConfirmationModal({
       style={{ maxWidth: "36rem" }}
     >
       <div className="p-6 flex flex-col items-center">
-        {/* Success Icon */}
         {position?.status === PositionStatus.LP_POSITION_DEPOSIT_PENDING ||
         position?.status === PositionStatus.LP_POSITION_WITHDRAWAL_PENDING ? (
           <div className="mb-3">
@@ -71,69 +101,16 @@ export default function TransactionConfirmationModal({
           </div>
         )}
 
-        {/* Message */}
         <p className="text-lg text-center mb-6">
           Your transaction has been submitted to the network
         </p>
 
-        {/* Explorer Links */}
         <div className="w-full space-y-3">
-          {assetHash && (
-            <>
-              <a
-                href={assetHashThorchainUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex items-center justify-center w-full p-4 bg-white rounded-xl hover:bg-gray-50 transition-colors border text-foreground group"
-              >
-                <span className="mr-2">
-                  View {chainName} transaction on THORChain.net
-                </span>
-                <ExternalLinkIcon />
-              </a>
-
-              <a
-                href={assetHashRunescanUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex items-center justify-center w-full p-4 bg-white rounded-xl hover:bg-gray-50 transition-colors border text-foreground group"
-              >
-                <span className="mr-2">
-                  View {chainName} transaction on Runescan
-                </span>
-                <ExternalLinkIcon />
-              </a>
-            </>
-          )}
-
-          {runeHash && (
-            <>
-              <a
-                href={runeHashThorchainUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex items-center justify-center w-full p-4 bg-white rounded-xl hover:bg-gray-50 transition-colors border text-foreground group"
-              >
-                <span className="mr-2">
-                  View Rune transaction on THORChain.net
-                </span>
-                <ExternalLinkIcon />
-              </a>
-
-              <a
-                href={runeHashRunescanUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="flex items-center justify-center w-full p-4 bg-white rounded-xl hover:bg-gray-50 transition-colors border text-foreground group"
-              >
-                <span className="mr-2">View Rune transaction on Runescan</span>
-                <ExternalLinkIcon />
-              </a>
-            </>
-          )}
+          {[...links.asset, ...links.rune].map((link, index) => (
+            <ExplorerLink key={index} {...link} />
+          ))}
         </div>
 
-        {/* Hash Preview */}
         <div className="mt-4 text-sm text-gray-500 truncate max-w-full">
           {assetHash && <p>{`${chainName} Transaction Hash: ${assetHash}`}</p>}
           {runeHash && <p>{`Rune Transaction Hash: ${runeHash}`}</p>}

--- a/app/app/explore/components/TransactionConfirmationModal.tsx
+++ b/app/app/explore/components/TransactionConfirmationModal.tsx
@@ -8,7 +8,7 @@ import {
 interface TransactionConfirmationModalProps {
   position: PositionStats | null;
   assetHash: string | null;
-  runeHash: string | null;
+  runeHash?: string | null;
   onClose: () => void;
 }
 
@@ -19,9 +19,9 @@ export default function TransactionConfirmationModal({
   onClose,
 }: TransactionConfirmationModalProps) {
   const assetHashThorchainUrl = `https://thorchain.net/tx/${assetHash}`;
-  const runeHashThorchainUrl = runeHash ? `https://thorchain.net/tx/${runeHash}` : null;
+  const runeHashThorchainUrl = runeHash ? `https://thorchain.net/tx/${runeHash}` : undefined;
   const assetHashRunescanUrl = `https://runescan.io/tx/${assetHash}`;
-  const runeHashRunescanUrl = runeHash ? `https://runescan.io/tx/${runeHash}` : null;
+  const runeHashRunescanUrl = runeHash ? `https://runescan.io/tx/${runeHash}` : undefined;
 
   const ExternalLinkIcon = () => (
     <svg

--- a/app/app/explore/components/TransactionConfirmationModal.tsx
+++ b/app/app/explore/components/TransactionConfirmationModal.tsx
@@ -7,18 +7,21 @@ import {
 
 interface TransactionConfirmationModalProps {
   position: PositionStats | null;
-  txHash: string;
+  assetHash: string | null;
+  runeHash: string | null;
   onClose: () => void;
 }
 
 export default function TransactionConfirmationModal({
   position,
-  txHash,
+  assetHash,
+  runeHash,
   onClose,
 }: TransactionConfirmationModalProps) {
-  const txHashes = txHash.split(",");
-  const thorchainUrl = `https://thorchain.net/tx/${txHashes[0]}`;
-  const runescanUrl = txHashes[1] ? `https://runescan.io/tx/${txHashes[1]}` : null;
+  const assetHashThorchainUrl = `https://thorchain.net/tx/${assetHash}`;
+  const runeHashThorchainUrl = runeHash ? `https://thorchain.net/tx/${runeHash}` : null;
+  const assetHashRunescanUrl = `https://runescan.io/tx/${assetHash}`;
+  const runeHashRunescanUrl = runeHash ? `https://runescan.io/tx/${runeHash}` : null;
 
   const ExternalLinkIcon = () => (
     <svg
@@ -71,7 +74,7 @@ export default function TransactionConfirmationModal({
         {/* Explorer Links */}
         <div className="w-full space-y-3">
           <a
-            href={thorchainUrl}
+            href={assetHashThorchainUrl}
             target="_blank"
             rel="noopener noreferrer"
             className="flex items-center justify-center w-full p-4 bg-white rounded-xl hover:bg-gray-50 transition-colors border text-foreground group"
@@ -80,22 +83,45 @@ export default function TransactionConfirmationModal({
             <ExternalLinkIcon />
           </a>
 
-          {runescanUrl && (
-            <a
-              href={runescanUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center justify-center w-full p-4 bg-white rounded-xl hover:bg-gray-50 transition-colors border text-foreground group"
-            >
-              <span className="mr-2">View on Runescan</span>
-              <ExternalLinkIcon />
-            </a>
+          <a
+            href={assetHashRunescanUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center justify-center w-full p-4 bg-white rounded-xl hover:bg-gray-50 transition-colors border text-foreground group"
+          >
+            <span className="mr-2">View on Runescan</span>
+            <ExternalLinkIcon />
+          </a>
+
+          {runeHash && (
+            <>
+              <a
+                href={runeHashThorchainUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center justify-center w-full p-4 bg-white rounded-xl hover:bg-gray-50 transition-colors border text-foreground group"
+              >
+                <span className="mr-2">View Rune on THORChain.net</span>
+                <ExternalLinkIcon />
+              </a>
+
+              <a
+                href={runeHashRunescanUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center justify-center w-full p-4 bg-white rounded-xl hover:bg-gray-50 transition-colors border text-foreground group"
+              >
+                <span className="mr-2">View Rune on Runescan</span>
+                <ExternalLinkIcon />
+              </a>
+            </>
           )}
         </div>
 
         {/* Hash Preview */}
         <div className="mt-4 text-sm text-gray-500 truncate max-w-full">
-          Hash: {txHashes.join(", ")}
+          Asset Transaction Hash: {assetHash}
+          {runeHash && `Rune Transaction Hash: ${runeHash}`}
         </div>
       </div>
     </Modal>

--- a/app/app/explore/components/TransactionConfirmationModal.tsx
+++ b/app/app/explore/components/TransactionConfirmationModal.tsx
@@ -19,9 +19,13 @@ export default function TransactionConfirmationModal({
   onClose,
 }: TransactionConfirmationModalProps) {
   const assetHashThorchainUrl = `https://thorchain.net/tx/${assetHash}`;
-  const runeHashThorchainUrl = runeHash ? `https://thorchain.net/tx/${runeHash}` : undefined;
+  const runeHashThorchainUrl = runeHash
+    ? `https://thorchain.net/tx/${runeHash}`
+    : undefined;
   const assetHashRunescanUrl = `https://runescan.io/tx/${assetHash}`;
-  const runeHashRunescanUrl = runeHash ? `https://runescan.io/tx/${runeHash}` : undefined;
+  const runeHashRunescanUrl = runeHash
+    ? `https://runescan.io/tx/${runeHash}`
+    : undefined;
 
   const ExternalLinkIcon = () => (
     <svg

--- a/app/app/explore/components/TransactionConfirmationModal.tsx
+++ b/app/app/explore/components/TransactionConfirmationModal.tsx
@@ -4,7 +4,6 @@ import {
   PositionStats,
   PositionStatus,
 } from "@/hooks/dataTransformers/positionsTransformer";
-import { useMemo } from "react";
 
 interface TransactionConfirmationModalProps {
   position: PositionStats | null;
@@ -27,16 +26,7 @@ export default function TransactionConfirmationModal({
   const runeHashRunescanUrl = runeHash
     ? `https://runescan.io/tx/${runeHash}`
     : undefined;
-
-  const getChainNameFromPosition = (position: PositionStats | null) => {
-    if (!position) return "";
-    const poolName = position.pool.asset;
-    return poolName.split(".")[0];
-  };
-  const chainName = useMemo(
-    () => getChainNameFromPosition(position),
-    [position],
-  );
+  const chainName = position ? position.pool.asset.split(".")[0] : "";
 
   const ExternalLinkIcon = () => (
     <svg
@@ -146,7 +136,7 @@ export default function TransactionConfirmationModal({
         {/* Hash Preview */}
         <div className="mt-4 text-sm text-gray-500 truncate max-w-full">
           {assetHash && <p>{`${chainName} Transaction Hash: ${assetHash}`}</p>}
-          {runeHash && <p>{`Rune Transaction Hash: ${runeHash}</p>`}</p>}
+          {runeHash && <p>{`Rune Transaction Hash: ${runeHash}`}</p>}
         </div>
       </div>
     </Modal>

--- a/app/hooks/useContracts.ts
+++ b/app/hooks/useContracts.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useMemo } from "react";
 import {
   parseUnits,
   formatUnits,

--- a/app/hooks/useLiquidityPosition.ts
+++ b/app/hooks/useLiquidityPosition.ts
@@ -135,6 +135,7 @@ export function useLiquidityPosition({
       try {
         setLoading(true);
         setError(null);
+
         let wallet = getAssetWallet(asset);
         const memo = getLiquidityMemo(
           "add",

--- a/app/hooks/useLiquidityPosition.ts
+++ b/app/hooks/useLiquidityPosition.ts
@@ -109,6 +109,11 @@ export function useLiquidityPosition({
     }
   }, [assetIdentifier, isNativeAsset]);
 
+  const getAssetWallet = useCallback((asset: string) => {
+    const [chain, _] = parseAssetString(asset);
+    return walletsState![getChainKeyFromChain(chain)];
+  }, []);
+
   const { approveSpending, getAllowance, depositWithExpiry, parseAmount } =
     useContracts({
       tokenAddress: tokenAddress as Address | undefined,
@@ -122,7 +127,7 @@ export function useLiquidityPosition({
     removeLiquidity: removeUTXOLiquidity,
   } = useUTXO({
     chain: utxoChain as "BTC" | "DOGE" | "LTC" | "BCH",
-    wallet: utxoChain ? wallet : null,
+    wallet: utxoChain ? getAssetWallet(pool.asset) : null,
   });
 
   const getMemberDetails = useCallback(
@@ -190,7 +195,7 @@ export function useLiquidityPosition({
       pairedAddress,
       runeAmount,
     }: AddLiquidityParams) => {
-      if (!wallet?.address) {
+      if (!getAssetWallet(asset)?.address) {
         throw new Error("Wallet not connected");
       }
       try {
@@ -216,7 +221,7 @@ export function useLiquidityPosition({
         );
 
         // Handle Thorchain deposits
-        if (wallet.chainType === ChainKey.THORCHAIN) {
+        if (getAssetWallet(asset).chainType === ChainKey.THORCHAIN) {
           return await thorChainClient.deposit({
             pool,
             recipient: "",
@@ -305,7 +310,7 @@ export function useLiquidityPosition({
           }
         }
 
-        await getMemberDetails(wallet.address, asset);
+        await getMemberDetails(getAssetWallet(asset).address, asset);
         return txHash;
       } catch (err) {
         const errorMessage =
@@ -457,5 +462,6 @@ export function useLiquidityPosition({
     getMemberDetails,
     addLiquidity,
     removeLiquidity,
+    getAssetWallet,
   };
 }

--- a/app/hooks/useThorchain.ts
+++ b/app/hooks/useThorchain.ts
@@ -105,7 +105,6 @@ export function useThorchain({ wallet }: UseThorchainProps) {
                 setError(error.message);
                 reject(error);
               } else {
-                console.log("Deposit result:", result);
                 resolve(result || "");
               }
             },

--- a/app/hooks/useThorchain.ts
+++ b/app/hooks/useThorchain.ts
@@ -100,12 +100,13 @@ export function useThorchain({ wallet }: UseThorchainProps) {
               method: "deposit",
               params: [depositParams],
             },
-            (error: Error | null, result: TxResult | null) => {
+            (error: Error | null, result: string | null) => {
               if (error) {
                 setError(error.message);
                 reject(error);
               } else {
-                resolve(result?.hash || "");
+                console.log("Deposit result:", result);
+                resolve(result || "");
               }
             },
           );

--- a/app/utils/contexts/context.tsx
+++ b/app/utils/contexts/context.tsx
@@ -11,6 +11,7 @@ import React, {
   useCallback,
 } from "react";
 import {
+  ChainKey,
   CHAINS,
   ProviderKey,
   SUPPORTED_WALLETS,
@@ -46,6 +47,7 @@ interface AppStateContextType {
   isLoadingTokenList: boolean;
   detected: WalletType[];
   undetected: WalletType[];
+  isWalletConnected: (chainKey: ChainKey) => boolean;
 }
 
 const AppStateContext = createContext<AppStateContextType | undefined>(
@@ -423,6 +425,10 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
     setSelectedChains(connectedChains);
   }, [walletsState]);
 
+  const isWalletConnected = (chainKey: ChainKey) => {
+    return Boolean(walletsState[chainKey]?.address);
+  };
+
   return (
     <AppStateContext.Provider
       value={{
@@ -442,6 +448,7 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
         isLoadingTokenList,
         detected,
         undetected,
+        isWalletConnected,
       }}
     >
       {children}


### PR DESCRIPTION
**This PR fixes dual-sided liquidity addition functionality by:**

- Enabling separate asset and RUNE transactions with independent hashes
- Validating wallet connections for both chains before allowing dual-sided deposits
- Updating transaction confirmation UI to display both transaction hashes when applicable

***Key changes:***

- Split txHash into assetTxHash and runeTxHash for tracking separate transactions on TransactionConfirmationModal.tsx
- Added proper paired address handling for dual-sided deposits
- Updated wallet connection validation using new isWalletConnected helper
- Enhanced TransactionConfirmationModal to display chain-specific transaction details
- Refactored useLiquidityPosition hook to support dual-chain operations
- Added getAssetWallet utility to manage multi-chain wallet states