### PR TITLE
[YLD-157] Optimize detect wallets algorithm

### DIFF
--- a/app/app/explore/components/AddLiquidityModal.tsx
+++ b/app/app/explore/components/AddLiquidityModal.tsx
@@ -64,7 +64,7 @@ export default function AddLiquidityModal({
   const runeMinimalUnit = 1 / 10 ** DECIMALS;
   const runeBalance = useMemo(() => {
     if (!balanceList) return 0;
-    return balanceList[ChainKey.THORCHAIN]["THOR.RUNE"].balance;
+    return balanceList[ChainKey.THORCHAIN]["THOR.RUNE"]?.balance;
   }, [balanceList]);
   const assetBalance = useMemo(() => {
     if (!balanceList || !pool.asset) return 0;

--- a/app/utils/contexts/context.tsx
+++ b/app/utils/contexts/context.tsx
@@ -207,10 +207,7 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
         }
         case WalletKey.METAMASK: {
           if (
-            window.ethereum?.isMetaMask &&
-            !window.ethereum?.isVultisig &&
-            !window.ethereum?.isXDEFI &&
-            !window.ethereum?.isPhanthom
+            window.ethereum?.isMetaMask
           ) {
             SUPPORTED_WALLETS[walletKey].isAvailable = true;
             SUPPORTED_WALLETS[walletKey].chainConnect = {
@@ -273,10 +270,7 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
         }
         case WalletKey.PHANTOM: {
           if (
-            window.solana?.isPhantom &&
-            !window.solana?.isBraveWallet &&
-            !window.solana?.isXDEFI &&
-            !window.solana?.isOkxWallet
+            window.solana?.isPhantom
           ) {
             SUPPORTED_WALLETS[walletKey].isAvailable = true;
             SUPPORTED_WALLETS[walletKey].chainConnect = {

--- a/app/utils/contexts/context.tsx
+++ b/app/utils/contexts/context.tsx
@@ -206,9 +206,7 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
           break;
         }
         case WalletKey.METAMASK: {
-          if (
-            window.ethereum?.isMetaMask
-          ) {
+          if (window.ethereum?.isMetaMask) {
             SUPPORTED_WALLETS[walletKey].isAvailable = true;
             SUPPORTED_WALLETS[walletKey].chainConnect = {
               [ProviderKey.AVALANCHE]: async () =>
@@ -269,9 +267,7 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
           break;
         }
         case WalletKey.PHANTOM: {
-          if (
-            window.solana?.isPhantom
-          ) {
+          if (window.solana?.isPhantom) {
             SUPPORTED_WALLETS[walletKey].isAvailable = true;
             SUPPORTED_WALLETS[walletKey].chainConnect = {
               [ProviderKey.AVALANCHE]: async () =>

--- a/app/utils/wallet/handlers/handleConnect.ts
+++ b/app/utils/wallet/handlers/handleConnect.ts
@@ -65,10 +65,10 @@ export const connectWallet = async (wallet: any): Promise<any> => {
           { method: "request_accounts", params: [] },
           (error: any, accounts: string[]) => {
             if (error) {
-              reject(error)
+              reject(error);
             } else {
-              resolve(accounts[0])
-            };
+              resolve(accounts[0]);
+            }
           },
         );
       });

--- a/app/utils/wallet/handlers/handleConnect.ts
+++ b/app/utils/wallet/handlers/handleConnect.ts
@@ -59,12 +59,16 @@ export const connectWallet = async (wallet: any): Promise<any> => {
     case "xdefi-bch":
     case "xdefi-doge":
     case "xdefi-ltc":
+    case "xdefi-utxo":
       address = await new Promise((resolve, reject) => {
         wallet.provider.request(
           { method: "request_accounts", params: [] },
           (error: any, accounts: string[]) => {
-            if (error) reject(error);
-            else resolve(accounts[0]);
+            if (error) {
+              reject(error)
+            } else {
+              resolve(accounts[0])
+            };
           },
         );
       });
@@ -73,21 +77,6 @@ export const connectWallet = async (wallet: any): Promise<any> => {
         provider: wallet.provider,
         address,
       };
-    case "xdefi-utxo":
-      address = await wallet.provider.getAccounts();
-      return {
-        provider: wallet.provider,
-        address: address[0],
-      };
-    case "xdefi-solana":
-    case "phantom-solana": {
-      const resp = await wallet.provider.connect();
-
-      return {
-        provider: wallet.provider,
-        address: resp.publicKey.toString(),
-      };
-    }
     case "phantom-utxo":
       accounts = await wallet.provider.requestAccounts();
       return {
@@ -115,8 +104,6 @@ export const connectWallet = async (wallet: any): Promise<any> => {
     case "okx-avax":
     case "okx-bsc":
     case "okx-eth":
-      address = "";
-
       if (!wallet.provider.connect || wallet.provider.isConnected()) {
         let accounts = [];
         accounts = await wallet.provider.request({ method: "eth_accounts" });


### PR DESCRIPTION
## Description

Minor update to display Metamask and Phantom as detected despite of xdefi overwrite them. Related to the bug reported in linear, it seems that the Ctrl wallet uses as provider the selection of previously connected wallets, so Phatom appear despite of the Ctrol wallet is selected, since the Pathom wallet is linked to the dapp. 

To change the behavio it the dapp must be unlinked from the Phatom extension. We cannot force unlinking from the dapp side, it is a functionality of the wallet extension.