### PR TITLE
[YLD-199][Manual input process in the input field during symmetric position creation fails]

### DIFF
--- a/app/app/explore/components/AddLiquidityModal.tsx
+++ b/app/app/explore/components/AddLiquidityModal.tsx
@@ -68,8 +68,8 @@ export default function AddLiquidityModal({
     initialType === PositionType.SYM,
   );
   const [inputChanging, setInputChanging] = useState<InputChanging>("asset");
-
   const { positions, markPositionAsPending } = useLiquidityPositions();
+  const inputChangeConstraint = 0.01; // 1%
 
   const poolNativeDecimal = parseInt(pool.nativeDecimal);
   const assetMinimalUnit = 1 / 10 ** poolNativeDecimal;
@@ -89,19 +89,42 @@ export default function AddLiquidityModal({
       const newUsdValue =
         parseFloat(assetAmount) * parseFloat(pool.assetPriceUSD);
       const newRuneAmount = newUsdValue / runePriceUSD;
-      setRuneAmount(newRuneAmount.toFixed(6));
+      // Prevents changing input value when focusing on the other input without changing the value
+      if (
+        Math.abs((newRuneAmount - parseFloat(runeAmount)) / newRuneAmount) >
+        inputChangeConstraint
+      ) {
+        setRuneAmount(newRuneAmount.toFixed(6));
+      }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [assetAmount, pool.assetPriceUSD, runePriceUSD]);
+  }, [
+    assetAmount,
+    runeAmount,
+    pool.assetPriceUSD,
+    runePriceUSD,
+    inputChanging,
+  ]);
 
   useEffect(() => {
     if (runeAmount && inputChanging === "rune") {
       const newUsdValue = parseFloat(runeAmount) * runePriceUSD;
       const newAssetAmount = newUsdValue / parseFloat(pool.assetPriceUSD);
-      setAssetAmount(newAssetAmount.toFixed(poolNativeDecimal));
+      // Prevents changing input value when focusing on the other input without changing the value
+      if (
+        Math.abs((newAssetAmount - parseFloat(assetAmount)) / newAssetAmount) >
+        inputChangeConstraint
+      ) {
+        setAssetAmount(newAssetAmount.toFixed(poolNativeDecimal));
+      }
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [runeAmount, pool.assetPriceUSD, runePriceUSD, poolNativeDecimal]);
+  }, [
+    runeAmount,
+    assetAmount,
+    pool.assetPriceUSD,
+    runePriceUSD,
+    poolNativeDecimal,
+    inputChanging,
+  ]);
 
   const handleAssetValueChange = (values: NumberFormatValues) => {
     setAssetAmount(values.value);

--- a/app/app/explore/components/AssetInput.tsx
+++ b/app/app/explore/components/AssetInput.tsx
@@ -12,6 +12,7 @@ interface AssetInputProps {
   usdDecimalScale: number;
   assetBalance?: number;
   usdBalance?: number;
+  onFocus?: () => void;
 }
 
 export default function AssetInput({
@@ -24,12 +25,14 @@ export default function AssetInput({
   usdDecimalScale,
   assetBalance: balance,
   usdBalance,
+  onFocus,
 }: AssetInputProps) {
   return (
     <div className="bg-white rounded-xl p-4 mb-6">
       <div className="flex items-center gap-2 mb-2">
         <NumericFormat
           value={value}
+          onFocus={onFocus}
           onValueChange={onValueChange}
           placeholder="0"
           className="flex-1 text-xl font-medium outline-none"


### PR DESCRIPTION
### This PR improves the UX of dual-sided liquidity provision by:

- Tracking which input (asset/rune) the user is actively modifying
- Automatically calculating the equivalent amount in the other asset based on USD prices
- Adding validation to prevent exceeding maximum allowable amounts for either asset
- Removing redundant balance checks and simplifying price calculations
- Adding focus handlers to AssetInput component